### PR TITLE
Bump mongo

### DIFF
--- a/helmfile.d/05-mongodb.yaml
+++ b/helmfile.d/05-mongodb.yaml
@@ -9,6 +9,6 @@ repositories:
 releases:
 - name: mongodb
   chart: bitnami/mongodb
-  version: 10.0.5
+  version: 11.0.3
   values:
   - ./config/mongodb.yaml.gotmpl

--- a/helmfile.d/config/mongodb.yaml.gotmpl
+++ b/helmfile.d/config/mongodb.yaml.gotmpl
@@ -1,10 +1,3 @@
-image:
-  registry: docker.io
-  repository: bitnami/mongodb
-  tag: 4.4.2-debian-10-r0
-  pullPolicy: IfNotPresent
-  debug: false
-
 clusterDomain: cluster.local
 architecture: replicaset
 useStatefulSet: true
@@ -183,11 +176,6 @@ rbac:
 
 metrics:
   enabled: true
-  image:
-    registry: docker.io
-    repository: bitnami/mongodb-exporter
-    tag: 0.11.2-debian-10-r44
-    pullPolicy: IfNotPresent
 
   resources:
     limits: 


### PR DESCRIPTION
https://github.com/w3f/SecOps/issues/189

This only bumps the integration test version and is not really a real migration...